### PR TITLE
Load existing PR

### DIFF
--- a/bin/fk.sh
+++ b/bin/fk.sh
@@ -35,7 +35,7 @@ fpr()
       # assuming ssh remote since `fclone` clone from ssh remote by default
       repoName=$(git config --get remote.origin.url | xargs basename | cut -d'.' -f1)
       ownerName=$(git config --get remote.origin.url | cut -d'/' -f1 | cut -d':' -f2)
-      if  curl -Ls -o /dev/null -w "%{url_effective}"  https://github.com/$ownerName/$repoName/pull/$curBranch | xargs curl -s -o /dev/null -w "%{http_code}" | grep 200 > /dev/null; then
+      if curl -s https://github.com/$ownerName/$repoName/pull/$curBranch | grep -o "href=\".*\"" | grep -v new; then
         xdg-open https://github.com/$ownerName/$repoName/pull/$curBranch &> /dev/null
       else
         xdg-open https://github.com/$ownerName/$repoName/pull/new/$curBranch &> /dev/null

--- a/bin/fk.sh
+++ b/bin/fk.sh
@@ -35,7 +35,11 @@ fpr()
       # assuming ssh remote since `fclone` clone from ssh remote by default
       repoName=$(git config --get remote.origin.url | xargs basename | cut -d'.' -f1)
       ownerName=$(git config --get remote.origin.url | cut -d'/' -f1 | cut -d':' -f2)
-      xdg-open https://github.com/$ownerName/$repoName/pull/new/$curBranch &> /dev/null
+      if  curl -Ls -o /dev/null -w "%{url_effective}"  https://github.com/$ownerName/$repoName/pull/$curBranch | xargs curl -s -o /dev/null -w "%{http_code}" | grep 200 > /dev/null; then
+        xdg-open https://github.com/$ownerName/$repoName/pull/$curBranch &> /dev/null
+      else
+        xdg-open https://github.com/$ownerName/$repoName/pull/new/$curBranch &> /dev/null
+      fi
     else
       echo "cannot open PR for master branch"
     fi

--- a/bin/fk.sh
+++ b/bin/fk.sh
@@ -18,7 +18,7 @@ fclone()
     fi
   else
     echo "Cloning from git@github.com:$(git config user.name)/$1.git"
-    if [ ! -d $HOME/src/github.com/$cdDir ]; then
+    if [[ ! -d $HOME/src/github.com/$cdDir ]]; then
       git clone git@github.com:$(git config user.name)/$1.git $HOME/src/github.com/$1
     else
       echo "Already cloned, done."
@@ -35,8 +35,11 @@ fpr()
       # assuming ssh remote since `fclone` clone from ssh remote by default
       repoName=$(git config --get remote.origin.url | xargs basename | cut -d'.' -f1)
       ownerName=$(git config --get remote.origin.url | cut -d'/' -f1 | cut -d':' -f2)
-      if pr-exists.rb repoName ownerName curBranch; then
+      pr-exists.rb repoName ownerName curBranch
+      if [[ $? -eq 0 ]]; then
         xdg-open https://github.com/$ownerName/$repoName/pull/new/$curBranch &> /dev/null
+      elif [[ $? -eq 2 ]]; then
+        return 1
       else
         xdg-open https://github.com/$ownerName/$repoName/pull/$curBranch &> /dev/null
       fi

--- a/bin/fk.sh
+++ b/bin/fk.sh
@@ -35,10 +35,10 @@ fpr()
       # assuming ssh remote since `fclone` clone from ssh remote by default
       repoName=$(git config --get remote.origin.url | xargs basename | cut -d'.' -f1)
       ownerName=$(git config --get remote.origin.url | cut -d'/' -f1 | cut -d':' -f2)
-      if curl -s https://github.com/$ownerName/$repoName/pull/$curBranch | grep -o "href=\".*\"" | grep -v new; then
-        xdg-open https://github.com/$ownerName/$repoName/pull/$curBranch &> /dev/null
-      else
+      if pr-exists.rb repoName ownerName curBranch; then
         xdg-open https://github.com/$ownerName/$repoName/pull/new/$curBranch &> /dev/null
+      else
+        xdg-open https://github.com/$ownerName/$repoName/pull/$curBranch &> /dev/null
       fi
     else
       echo "cannot open PR for master branch"

--- a/bin/pr-exists.rb
+++ b/bin/pr-exists.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+# takes 3 argument:
+# ARGV[0] = repo owner
+# ARGV[1] = repo name
+# ARGV[2] = current branch name
+# returns 0 if repo exists else returns 1
+
+require 'net/http'
+require 'json'
+
+repo_owner  = ARGV[0]
+repo_name   = ARGV[1]
+branch_name = ARGV[2]
+
+uri = URI("https://api.github.com/repos/#{repo_owner}/#{repo_name}/pulls?head=#{repo_owner}:#{branch_name}")
+res = Net::HTTP.get(uri)
+
+data = JSON.parse(res)
+
+exit(1) unless data.kind_of?(Array) && data.first.has_key?('url')

--- a/bin/pr-exists.rb
+++ b/bin/pr-exists.rb
@@ -4,7 +4,8 @@
 # ARGV[0] = repo owner
 # ARGV[1] = repo name
 # ARGV[2] = current branch name
-# returns 0 if repo exists else returns 1
+#
+# returns 0 if repo exists else returns 1, returns 2 if an errror occurred
 
 require 'net/http'
 require 'json'
@@ -13,9 +14,13 @@ repo_owner  = ARGV[0]
 repo_name   = ARGV[1]
 branch_name = ARGV[2]
 
-uri = URI("https://api.github.com/repos/#{repo_owner}/#{repo_name}/pulls?head=#{repo_owner}:#{branch_name}")
-res = Net::HTTP.get(uri)
-
-data = JSON.parse(res)
+begin
+  uri = URI("https://api.github.com/repos/#{repo_owner}/#{repo_name}/pulls?head=#{repo_owner}:#{branch_name}")
+  res = Net::HTTP.get(uri)
+  data = JSON.parse(res)
+rescue => e
+  puts "Unable to query github: #{e}"
+  exit(2)
+end
 
 exit(1) unless data.kind_of?(Array) && data.first.has_key?('url')


### PR DESCRIPTION
Close #4 

Hacky solution: curl the github url to see if the PR with current branch name is being created, github will do a 302 redirect then grep to see if the "new" is present in the redirecting url

Weird behaviour on github side, if my branch name is prefixed with `az.` then it will return a redirect url for me to open PR, but if the branch name does not contain that prefix it will just return a 404. 

However the new script handles both cases regardless 