### PR TITLE
Set up root src path during installation process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 # install oh-my-zsh
 RUN apt-get update && \
-  apt-get install -y git curl vim locales gnupg2 zsh ruby && \
+  apt-get install -y git curl vim locales zsh ruby && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   chsh -s $(which zsh)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM zshusers/zsh-5.6.2
+FROM ubuntu:18.04
 
 # install oh-my-zsh
 RUN apt-get update && \
-  apt-get install -y git ruby curl vim locales && \
+  apt-get install -y git curl vim locales gnupg2 zsh ruby && \
   apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* && \
+  chsh -s $(which zsh)
+
 RUN curl -fsSL https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh | zsh || true
 
 # fix docker zsh locale setup
@@ -22,3 +24,4 @@ RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.
   git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
 
 WORKDIR /root
+CMD ["zsh"]

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -29,9 +29,11 @@ fi
 mkdir -p $kitConfigDir
 echo $(date +'%s') > $kitConfigDir/lastUpdated
 
-read -p "Setting up root source repository path: (default: $kitRootSrcDir)" rootSrcDir < /dev/tty
+read -p "Setting up root source repository path (default: $kitRootSrcDir): " rootSrcDir < /dev/tty
 if [[ -n $rootSrcDir ]]; then
-  kitRootSrcDir=$rootSrcDir
+  eval expandedPath=$rootSrcDir
+  kitRootSrcDir=$expandedPath
+  echo "Creating directory: $kitRootSrcDir"
 fi
 
 currentVersion=$(git --git-dir="$kitDir/.git" rev-parse HEAD)

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -39,6 +39,7 @@ fi
 currentVersion=$(git --git-dir="$kitDir/.git" rev-parse HEAD)
 mkdir -p $kitRootSrcDir
 erb sha="$currentVersion" rootSrcPath="$kitRootSrcDir" "$kitDir/configs/default_config.yml.erb" > "$kitConfigDir/config.yml"
+cp "$kitConfigDir/config.yml" "$kitConfigDir/.config.yml.backup" # back a copy of the config file as backup
 
 echo -e "Appending following configurations to ~/.zshrc\e[91m"
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -8,6 +8,7 @@ appendIfNotExist() {
 
 kitDir=$HOME/.fantastic-kit
 kitConfigDir=$HOME/.config/fantastic-kit
+kitRootSrcDir=$HOME/src/github.com
 
 # in case user has already installed fk, nuke everything and reinstall
 if [[ -d $kitDir ]]; then
@@ -26,8 +27,16 @@ fi
 
 # setup $HOME/.config/fantastic-kit
 mkdir -p $kitConfigDir
-cp $kitDir/configs/default_config.yml $kitConfigDir/config.yml
 echo $(date +'%s') > $kitConfigDir/lastUpdated
+
+read -p "Setting up root source repository path: (default: $kitRootSrcDir)" rootSrcDir < /dev/tty
+if [[ -n $rootSrcDir ]]; then
+  kitRootSrcDir=$rootSrcDir
+fi
+
+currentVersion=$(git --git-dir="$kitDir/.git" rev-parse HEAD)
+mkdir -p $kitRootSrcDir
+erb sha="$currentVersion" rootSrcPath="$kitRootSrcDir" "$kitDir/configs/default_config.yml.erb" > "$kitConfigDir/config.yml"
 
 echo -e "Appending following configurations to ~/.zshrc\e[91m"
 

--- a/configs/default_config.yml.erb
+++ b/configs/default_config.yml.erb
@@ -2,4 +2,5 @@
 autoUpdateEnabled: true
 updatePollIntervalS: 7200 # 60s * 60m * 2 = 7200
 branch: Rolling
-sha: null
+sha: <%= sha %>
+rootSrcPath: <%= rootSrcPath %>

--- a/kit.yml
+++ b/kit.yml
@@ -5,14 +5,13 @@ commands:
   build:
     run: docker build -t="omz" .
     desc: building the docker image used to test the project
-  docker:
+  docker-clean:
     run: docker run -it --rm --name zsh -v $HOME/src/github.com/fantastic-kit/bin/install.sh:/root/install.sh -v $HOME/.ssh:/root/.ssh -v $HOME/.gitconfig/:/root/.gitconfig omz
     desc: mount the installation script
-  docker-installed:
+  docker-dev:
     run:
       docker run -it --rm --name zsh
         --mount type=bind,source=$HOME/src/github.com/fantastic-kit/bin/install.sh,target=/root/install.sh,readonly
-        --mount type=bind,source=$HOME/src/github.com/fantastic-kit/configs/default_config.yml,target=/root/.config/fantastic-kit/config.yml,readonly
         --mount type=bind,source=$HOME/.ssh,target=/root/.ssh,readonly
         --mount type=bind,source=$HOME/.gitconfig,target=/root/.gitconfig,readonly
         --mount type=bind,source=$HOME/src/github.com/fantastic-kit/misc/zshrc_installed,target=/root/.zshrc,readonly

--- a/lib/fkit/configs.rb
+++ b/lib/fkit/configs.rb
@@ -4,6 +4,7 @@ require 'fileutils'
 module FKit
   class Configs
     CONFIG_PATH = "#{ENV['HOME']}/.config/fantastic-kit/config.yml".freeze
+    CONFIG_BACKUP = "#{ENV['HOME']}/.config/fantastic-kit/.config.yml.backup".freeze
 
     # key constants
     AUTO_UPDATE_ENABLED = 'autoUpdateEnabled'.freeze
@@ -43,7 +44,13 @@ Usage: fk config [options]
 
     def ensure_configs_file_exist
       unless File.exist?(CONFIG_PATH)
-        FileUtils.cp DEFAULT_CONFIG_PATH, CONFIG_PATH
+        puts 'Corrupt config file detected, attempting repair...'
+        if File.file?(CONFIG_BACKUP)
+          FileUtils.cp CONFIG_BACKUP, CONFIG_PATH
+          puts 'Repair done.'
+        else
+          raise 'Unable to restore config file, please try reinstall fantastic-kit'
+        end
       end
     end
 


### PR DESCRIPTION
Set up `rootSrcPath` variable in the config file during installation process. 
Modify the `default_config.yml` to use erb for easier templating.
Change the docker image to use `ubuntu:18:04` base image since the ruby version from `zsh:5.6.1` image is way to old. 
Also Close #43 
Required for #47 
Depends on #46 