### PR TITLE
Introduce fk up

### DIFF
--- a/lib/fkit/help.rb
+++ b/lib/fkit/help.rb
@@ -1,6 +1,7 @@
 module FKit
   HELP_MSG = <<-EOF
 Usage: fk [cmd] (subcmd|options)
+  fk \e[94mup\e[39m           -- Create a new repository on github that is tracked by fantastic-kit
   fk \e[94mcd\e[39m           -- cd into a project tracked by fantastic-kit
   fk \e[94mclone\e[39m        -- clone a repository from GitHub
   fk \e[94mpr\e[39m           -- create a GitHub pull request for current repo


### PR DESCRIPTION
Allows user to create a repository on github from CLI

Currently requires user to enter password to create the repository

![image](https://user-images.githubusercontent.com/4193035/75755480-8fe98980-5ce3-11ea-9990-12beb53453c5.png)

Ideally merge this after #58, but `-u` flag allows it to be used with current setup or if the user wants to create a repository under another username than the one configured with fk.